### PR TITLE
Readme: Fix image folder config property name

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@ extensions:
     embeddedSvg: Milo\EmbeddedSvg\Extension
 
 embeddedSvg:
-    basePath: %wwwDir%/img
+    baseDir: %wwwDir%/img
 ```
 
 


### PR DESCRIPTION
First, thanks for the great extension!

Second, I found a typo in the readme file that got me a little stumped.

The `MacroSetting` class has no property `basePath`, only `baseDir`. When I went by readme instructions, I got "Cannot write to an undeclared property..." Exception.